### PR TITLE
Rum: Add Wine build linked against older glibc

### DIFF
--- a/Guides/Rum/Guide.md
+++ b/Guides/Rum/Guide.md
@@ -33,7 +33,7 @@ First, we'll create two directories in `~/.local/share/` which will help us orga
 
 ```bash
 mkdir -p ~/.local/share/wine/runners
-mkdir -p ~/.local/share/wine/prefixes
+mkdir -p ~/.local/share/wine/prefixes/affinity
 ```
 
 ## Wine Runner Download


### PR DESCRIPTION
This allows ZorinOS and other systems based on Ubuntu 22.04 to run ElementalWarrior's wine. More specifically, my build was linked against glibc 2.35.

- Make user check for current glibc version installed and direct them to the proper build
-  Shorten note about other shells (the guide assumes that if a user is running anything other than bash, they probably know or can figure out where to put aliases)

- remove `--force` flag from winetricks install

- Remove unneeded steps from DPI fix

Resolves #53 

TODO: 

- [ ] Succesful test on ZorinOS