### PR TITLE
Replace discord link with github link for nix method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ _A repository containing information on how to get Affinity software working on 
   - Affinity by Canva - Sign in is not working at the moment. Looking for solutions.
   - UI settings does not save. There is a [workaround](Guides/Settings.md).
   - Affinity V1 - [purchased via windows store issue](https://github.com/seapear/AffinityOnLinux/blob/main/FAQ.md#which-affinity-versions-are-supported)
-  - Unofficial [NixOS method](https://github.com/mrshmllow/affinity-nix)
+  - Unofficial [Nix method](https://github.com/mrshmllow/affinity-nix)
 
 [🗺️ Roadmap & ⚠️ Known issues](/Roadmap.md)
 


### PR DESCRIPTION
so people dont need to create a discord account and join the server, also swap nixos for nix since this will work with the nix package manage on other distros
