### PR TITLE
Heroic and Bottles: Clarify step for copying and pasting extracted Wine fork folder

### DIFF
--- a/Guides/Bottles/Guide.md
+++ b/Guides/Bottles/Guide.md
@@ -30,10 +30,10 @@ Choose one of the following forks of Wine, and download and extract it:
 
 Bottles' Wine-related folders can be found in a hidden directory within your `home` folder. If you can't see hidden folders in your file browser, you can usually enable them by pressing `Ctrl + H`.
 
-- If you installed Bottles via **Flatpak**, navigate to `/home/$USER/.var/app/com.usebottles.bottles/data/bottles/runners`
-- If you installed Bottles via **AppImage**, navigate to `/home/$USER/.local/share/bottles/runners`
+- If you installed Bottles via **Flatpak**, navigate to `/home/$USER/.var/app/com.usebottles.bottles/data/bottles/runners/`
+- If you installed Bottles via **AppImage**, navigate to `/home/$USER/.local/share/bottles/runners/`
 
-Copy and paste the folder you extracted in the previous step to this folder.
+Copy and paste the Wine fork folder you extracted in the previous step to this folder.
 
 This is also known as your Wine runner.
 

--- a/Guides/Heroic/Guide.md
+++ b/Guides/Heroic/Guide.md
@@ -26,10 +26,12 @@ Choose one of the following forks of Wine, and download and extract it:
 
 ## 3. Copy and Paste Wine Fork Binaries to Heroic Games Launcher
 
-Copy and paste the extracted Wine fork folder from the previous step to Heroic Games Launcher’s Wine directory:
+Heroic Games Launcher's Wine-related folders can be found in a hidden directory within your `home` folder. If you can't see hidden folders in your file browser, you can usually enable them by pressing `Ctrl + H`.
 
-- **Flatpak:** `~/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools/wine`
-- **Other Install Methods:** `~/.config/heroic/tools/wine`
+- If you installed Heroic Games Launcher via **Flatpak**, navigate to `/home/$USER/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools/wine/`
+- If you installed Heroic Games Launcher via other methods, navigate to `/home/$USER/.config/heroic/tools/wine/`
+
+Copy and paste the Wine fork folder you extracted in the previous step to this folder.
 
 ## 4. Add Game in Heroic Games Launcher
 

--- a/Guides/Lutris/Guide.md
+++ b/Guides/Lutris/Guide.md
@@ -61,7 +61,7 @@ Lutris' Wine-related folders can be found in a hidden directory within your `hom
 - If you installed Lutris via **Flatpak**, navigate to `/home/$USER/.var/app/net.lutris.Lutris/data/lutris/runners/`
 - If you installed Lutris via **AppImage** or other methods, navigate to `/home/$USER/.local/share/lutris/runners/`
 
-Create a folder called `wine` if one does not already exist, then copy and paste the folder you extracted in the previous step to this folder.
+Create a folder called `wine` if one does not already exist, then copy and paste the Wine fork folder you extracted in the previous step to this folder.
 
 This is also known as your Wine runner.
 


### PR DESCRIPTION
This PR aims to improve the guides for installing Affinity software with Heroic Games Launcher or Bottles, by clarifying the step involving copying and pasting an extracted Wine fork to the Wine runners' directory.

I made these changes after realising some new Linux user in the AffinityOnLinux Discord server did not understand the step, so I decided to make the step clearer based on the Lutris guide.