### PR TITLE
Fix typo in 'How to Fix Stuttering' section

### DIFF
--- a/Guides/Bottles/Guide.md
+++ b/Guides/Bottles/Guide.md
@@ -67,7 +67,7 @@ The Affinity apps installed with Bottles are located at the following location:
 
 - **Flatpak**: `~/.var/app/com.usebottles.bottles/data/bottles/bottles/Affinity/drive_c`
 
-### How to Fix Studdering
+### How to Fix Stuttering
 
 - Bottles -> Settings -> # Performance | Toggle on Feral GameMode
 - Bottles -> Settings -> # Compatibility | Windows 10 -> Windows 11 [*](https://discord.com/channels/1281706644073611358/1289640098589315174/1418124555406544956)


### PR DESCRIPTION
Previously said "Studdering." Unless this is a term I don't know, I believe this is a typo.