### PR TITLE
Script installer: remove no-op webview2 component; write dxvk.conf to fix black context menus (#72)

### DIFF
--- a/Guides/Wine/Script Installer/affinity_installer_unified.py
+++ b/Guides/Wine/Script Installer/affinity_installer_unified.py
@@ -435,6 +435,48 @@ install_affinity_app() {
 }
 
 # ==========================================
+# DXVK Workarounds
+# ==========================================
+
+configure_dxvk_workarounds() {
+    # Fix black right-click/context menus and flyout popups (issue #72).
+    # DXVK leaves Affinity's D3D9 popup surfaces uninitialised until they are
+    # presented (doitsujin/dxvk#2749); deferring surface creation and pinning
+    # shader model 1 works around it.
+    log "Configuring DXVK workarounds (black context menu fix)"
+
+    local affinity_exe=$(find "$WINEPREFIX/drive_c" -name "Affinity.exe" 2>/dev/null | head -1)
+
+    if [ -z "$affinity_exe" ] || [ ! -f "$affinity_exe" ]; then
+        log "Affinity.exe not found, skipping dxvk.conf setup"
+        return 0
+    fi
+
+    local affinity_dir=$(dirname "$affinity_exe")
+
+    cat > "$affinity_dir/dxvk.conf" <<EOF
+# Fix black right-click/context menus and flyout popups in Affinity under
+# Wine (doitsujin/dxvk#2749): D3D9 popup surfaces stay uninitialised (black)
+# until presented. Deferring surface creation and pinning shader model 1
+# works around it.
+d3d9.deferSurfaceCreation = True
+d3d9.shaderModel = 1
+EOF
+
+    log "Wrote $affinity_dir/dxvk.conf"
+
+    # Register the config path prefix-wide so DXVK finds it regardless of the
+    # launcher's working directory. DXVK opens the value directly as a host
+    # path, so it must be the native Linux path, not a Z:\ Windows path.
+    WINEPREFIX="$WINEPREFIX" wine reg add "HKCU\\Environment" /v DXVK_CONFIG_FILE \
+        /d "$affinity_dir/dxvk.conf" /f 2>&1 | tee -a "$LOG_FILE"
+
+    log "Registered DXVK_CONFIG_FILE in HKCU\\Environment"
+
+    return 0
+}
+
+# ==========================================
 # Create Desktop Shortcuts
 # ==========================================
 
@@ -567,6 +609,9 @@ main() {
     # Install Affinity if installer provided
     if [ -n "$INSTALLER_PATH" ]; then
         install_affinity_app
+        if [ "$ENABLE_DXVK" = true ]; then
+            configure_dxvk_workarounds
+        fi
         create_desktop_shortcuts
     fi
     

--- a/Guides/Wine/Script Installer/affinity_installer_unified.py
+++ b/Guides/Wine/Script Installer/affinity_installer_unified.py
@@ -283,7 +283,11 @@ install_missing_components() {
     log "Installing all dependencies with winetricks"
     
     # Base components (always installed)
-    COMPONENTS="remove_mono vcrun2022 dotnet48 corefonts win11 webview2"
+    # Note: "webview2" is intentionally absent: winetricks has no such verb
+    # (passing it makes winetricks print its usage text and install nothing),
+    # and installing the WebView2 runtime by other means is known to make
+    # Affinity's onboarding/help dialogs hang under Wine.
+    COMPONENTS="remove_mono vcrun2022 dotnet48 corefonts win11"
     
     # Append optional components if enabled
     if [ "$ENABLE_DXVK" = true ]; then


### PR DESCRIPTION
Two fixes to `Guides/Wine/Script Installer/affinity_installer_unified.py`:

## 1. Drop `webview2` from the winetricks component list

winetricks has no `webview2` verb. When the component list reaches it, winetricks prints its usage/help text and installs nothing, so every install has been silently skipping it (check any prefix's `winetricks.log`: `webview2` never appears). Removing it makes the install honest. Leaving WebView2 out is also the desired behaviour: installing the Edge WebView2 runtime under Wine is reported to make Affinity's onboarding/help dialogs hang (see discussion in noahc3/AffinityPluginLoader#46).

## 2. Write `dxvk.conf` when DXVK is enabled, fixing black right-click menus (#72)

With DXVK enabled, Affinity's right-click/context menus and flyout popups render as black boxes (#72). This is doitsujin/dxvk#2749: DXVK leaves D3D9 popup surfaces uninitialised until they're presented, which hits WPF apps like Affinity. The fix already confirmed by several users in #72:

```
d3d9.deferSurfaceCreation = True
d3d9.shaderModel = 1
```

The installer now writes this to `dxvk.conf` next to `Affinity.exe` and registers the path as `DXVK_CONFIG_FILE` in `HKCU\Environment`. The value is the native Linux path, since DXVK opens it directly on the host. This way it applies no matter which launcher or working directory is used.

## Testing

Verified on Wine 11.13 + DXVK 3.0.2, Affinity 3.2.3.4646, Arch Linux, KDE Plasma Wayland, NVIDIA RTX 3090: with the config in place, canvas context menus render fully (previously solid black), and DXVK's log confirms `Effective configuration: d3d9.shaderModel = 1, d3d9.deferSurfaceCreation = True`. The embedded bash passes `bash -n` and the file passes `py_compile`.
